### PR TITLE
Build fixes for 1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ $RECYCLE.BIN/
 /.vs
 /Documentation/DocFxBin
 /Documentation/*.zip
+
+# JetBrains Rider
+/.idea

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.0",
+    "rollForward": "latestFeature"
+  }
+}

--- a/tools/common.props
+++ b/tools/common.props
@@ -6,9 +6,9 @@
     <Authors>MichaConrad</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <PackageIconUrl>http://cachemanager.michaco.net/favicon-128.png</PackageIconUrl>
+<!--    <PackageIconUrl>http://cachemanager.michaco.net/favicon-128.png</PackageIconUrl>-->
     <PackageProjectUrl>http://cachemanager.michaco.net</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/MichaCo/CacheManager/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicense>https://github.com/MichaCo/CacheManager/blob/master/LICENSE</PackageLicense>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/MichaCo/CacheManager</RepositoryUrl>
 


### PR DESCRIPTION
Minimal set of build fixes to get 1.x to build against more recent versions of the SDK:

- Change or disable deprecated items
- Add a global.json

## Deprecations

.NET Core 2.1 appears to have made two deprecations hard errors:

| Error | Description | Action |
|-|-|-|
| [NU5048] | The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead. Learn more at https://aka.ms/deprecateIconUrl | Commented out as the solution requires the icon to exist in each .csproj. |
| [NU5125] | The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. | Change to use `<PackageLicense>` with URL sufficient. |

## global.json

This was mainly so that I could build against a more stable version of the SDK as I have a 6.0 beta installed, and this forces it to use the latest 3.1 SDK.

[nu5048]: https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5048
[nu5125]: https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5125